### PR TITLE
Fix: disable empty variable of VariableStyle

### DIFF
--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,7 +1,7 @@
 import { Style } from '@master/style';
 
 export class VariableStyle extends Style {
-    static override matches = /^\$.*:./;
+    static override matches = /^\$.+:./;
     static override unit = ''; // don't use 'rem' as default, because css variable is common API
     override get props(): { [key: string]: any } {
         return {


### PR DESCRIPTION
Currently `styles` will parse `$:10` style class to
```css
.\$\:10 {
    --: 10;
}
```

But empty variable property (`--`) is invalid in CSS so I change the regex to make sure variable name is not empty.