### PR TITLE
Performance: update 'or' single letter regex to speed up

### DIFF
--- a/src/border-color.ts
+++ b/src/border-color.ts
@@ -4,7 +4,7 @@ import { getBorderProps } from './utils/get-border-props';
 
 export class BorderColorStyle extends Style {
     static override matches = /^border(-(left|right|top|bottom))?-color:./;
-    static override colorStarts = 'b((x|y|t|b|l|r)|(order(-(left|right|top|bottom))?))?:';
+    static override colorStarts = 'b([xytblr]|(order(-(left|right|top|bottom))?))?:';
     static override colorful = true;
     override get props(): { [key: string]: any } {
         return getBorderProps(this.prefix, this, COLOR);

--- a/src/border-radius.ts
+++ b/src/border-radius.ts
@@ -10,7 +10,7 @@ const BORDER_TOP_LEFT_RADIUS = BORDER + DASH + TOP + DASH + LEFT + DASH + RADIUS
     BORDER_RADIUS_S = [BORDER_TOP_LEFT_RADIUS, BORDER_TOP_RIGHT_RADIUS, BORDER_BOTTOM_LEFT_RADIUS, BORDER_BOTTOM_RIGHT_RADIUS];
 
 export class BorderRadiusStyle extends Style {
-    static override matches = /^((r(t|b|l|r)?(t|b|l|r)?|border(-(top|bottom)-(left|right))?-radius):.)/;
+    static override matches = /^((r[tblr]?[tblr]?|border(-(top|bottom)-(left|right))?-radius):.)/;
     static override semantics = {
         [ROUNDED]: '1e9em',
         [ROUND]: '50%'

--- a/src/border-style.ts
+++ b/src/border-style.ts
@@ -3,7 +3,7 @@ import { BORDER, DASH, STYLE } from './constants/css-property-keyword';
 import { getBorderProps } from './utils/get-border-props';
 
 export class BorderStyleStyle extends Style {
-    static override matches = /^(border(-(left|right|top|bottom))?-style:.|b(x|y|t|b|l|r|order(-(left|right|top|bottom))?)?:(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)(?!;))/;
+    static override matches = /^(border(-(left|right|top|bottom))?-style:.|b([xytblr]|order(-(left|right|top|bottom))?)?:(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)(?!;))/;
     override get props(): { [key: string]: any } {
         return getBorderProps(this.prefix, this, STYLE);
     }

--- a/src/border-width.ts
+++ b/src/border-width.ts
@@ -3,7 +3,7 @@ import { BORDER, DASH, WIDTH } from './constants/css-property-keyword';
 import { getBorderProps } from './utils/get-border-props';
 
 export class BorderWidthStyle extends Style {
-    static override matches = /^(border(-(left|right|top|bottom))?-width:.|b(x|y|t|b|l|r|order(-(left|right|top|bottom))?)?:(([0-9]|(max|min|calc|clamp)\(.*\))|(max|min|calc|clamp)\(.*\))((?!;).)*$)/;
+    static override matches = /^(border(-(left|right|top|bottom))?-width:.|b([xytblr]|order(-(left|right|top|bottom))?)?:(([0-9]|(max|min|calc|clamp)\(.*\))|(max|min|calc|clamp)\(.*\))((?!;).)*$)/;
     override get props(): { [key: string]: any } {
         return getBorderProps(this.prefix, this, WIDTH);
     }

--- a/src/border.ts
+++ b/src/border.ts
@@ -3,7 +3,7 @@ import { BORDER } from './constants/css-property-keyword';
 import { getBorderProps } from './utils/get-border-props';
 
 export class BorderStyle extends Style {
-    static override matches = /^b((x|y|t|b|l|r)?|order(-(left|right|top|bottom))?):./;
+    static override matches = /^b([xytblr]?|order(-(left|right|top|bottom))?):./;
     static override colorful = true;
     override get props(): { [key: string]: any } {
         return getBorderProps(this.prefix, this);

--- a/src/scroll-margin.ts
+++ b/src/scroll-margin.ts
@@ -3,7 +3,7 @@ import { DASH, MARGIN, SCROLL } from './constants/css-property-keyword';
 import { B, BOTTOM, L, LEFT, R, RIGHT, T, TOP, X, Y } from './constants/direction';
 
 export class ScrollMarginStyle extends Style {
-    static override matches = /^scroll-m(x|y|t|b|l|r|argin(-(top|bottom|left|right))?)?:./;
+    static override matches = /^scroll-m([xytblr]|argin(-(top|bottom|left|right))?)?:./;
     override get props(): { [key: string]: any } {
         if (this.prefix.slice(-3, -2) === 'm') {
             const SCROLL_MARGIN_PREFIX = SCROLL + DASH + MARGIN + DASH,

--- a/src/scroll-padding.ts
+++ b/src/scroll-padding.ts
@@ -3,7 +3,7 @@ import { DASH, PADDING, SCROLL } from './constants/css-property-keyword';
 import { B, BOTTOM, L, LEFT, R, RIGHT, T, TOP, X, Y } from './constants/direction';
 
 export class ScrollPaddingStyle extends Style {
-    static override matches = /^scroll-p(x|y|t|b|l|r|adding(-(top|bottom|left|right))?)?:./;
+    static override matches = /^scroll-p([xytblr]|adding(-(top|bottom|left|right))?)?:./;
     override get props(): { [key: string]: any } {
         if (this.prefix.slice(-3, -2) === 'p') {
             const SCROLL_PADDING_PREFIX = SCROLL + DASH + PADDING + DASH,

--- a/src/scroll-snap-type.ts
+++ b/src/scroll-snap-type.ts
@@ -2,6 +2,6 @@ import { Style } from '@master/style';
 import { DASH, SCROLL, SNAP, TYPE } from './constants/css-property-keyword';
 
 export class ScrollSnapTypeStyle extends Style {
-    static override matches = /^scroll-snap:((x|y|block|inline|both)(;(proximity|mandatory))?)(?!;)/
+    static override matches = /^scroll-snap:(([xy]|block|inline|both)(;(proximity|mandatory))?)(?!;)/
     static override key = SCROLL + DASH + SNAP + DASH + TYPE;
 }

--- a/src/spacing.ts
+++ b/src/spacing.ts
@@ -3,7 +3,7 @@ import { DASH, MARGIN, PADDING } from './constants/css-property-keyword';
 import { B, BOTTOM, L, LEFT, R, RIGHT, T, TOP, X, Y } from './constants/direction';
 
 export class SpacingStyle extends Style {
-    static override matches = /^(p|m)(x|y|t|b|l|r)?:./;
+    static override matches = /^[pm][xytblr]?:./;
     override get props(): { [key: string]: any } {
         const charAt1 = this.prefix[0];
         const SPACING = charAt1 === 'm' ? MARGIN : PADDING;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,12 +2,12 @@ import { DEG, REM, ROTATE, SKEW, TRANSFORM, TRANSLATE } from './constants/css-pr
 import { Style } from '@master/style';
 
 export class TransformStyle extends Style {
-    static override matches = /^(translate|scale|skew|rotate|perspective|matrix)(3d|X|Y|Z)?\(/;
+    static override matches = /^(translate|scale|skew|rotate|perspective|matrix)(3d|[XYZ])?\(/;
     static override key = TRANSFORM;
     static override unit = '';
     override get parseValue() {
         return this.value.replace(
-            /(translate|scale|skew|rotate|perspective|matrix)(3d|X|Y|Z)?\((.*?)\)/gm,
+            /(translate|scale|skew|rotate|perspective|matrix)(3d|[XYZ])?\((.*?)\)/gm,
             (origin, method, type, valueStr: string) => {
                 let unit: string;
                 let last: boolean;


### PR DESCRIPTION
Using `(a|b|c|d)` in Regex is slower then `[abcd]`. After this improvement, parsing related strings will be nearly 20% faster.

![regex-1](https://user-images.githubusercontent.com/44749100/163726617-e71896b0-ed82-4dce-a030-fe08bc73e924.png)

![regex-2](https://user-images.githubusercontent.com/44749100/163726620-af88d51e-eff4-45ef-88a0-cddf0986d49e.png)

