### PR TITLE
Fix: remove text-stroke css property

### DIFF
--- a/src/text-stroke.ts
+++ b/src/text-stroke.ts
@@ -4,7 +4,6 @@ export class TextStrokeStyle extends Style {
     static override matches = /^text-stroke:./;
     override get props(): { [key: string]: any } {
         return {
-            'text-stroke': this,
             '-webkit-text-stroke': this
         };
     }


### PR DESCRIPTION
Regarding to the [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke) document, `text-stroke` is not exist and currently there is `-webkit-text-stroke` only.